### PR TITLE
Fixing cpu-or-gpu parameter bug to enable gaudi3

### DIFF
--- a/core/inference-stack-deploy.sh
+++ b/core/inference-stack-deploy.sh
@@ -236,18 +236,18 @@ read_config_file() {
             export no_proxy
         fi
         
-        
         case "$cpu_or_gpu" in
             "c" | "cpu")
             cpu_or_gpu="c"
             deploy_habana_ai_operator="no"
             ;;
             "g" | "gpu" | "gaudi2" | "gaudi3")
-            if [[ "$cpu_or_gpu" == "gaudi2" || "$cpu_or_gpu" == "gpu" || "$cpu_or_gpu" == "g" ]]; then
-                gaudi_platform="gaudi2"
-                
-            elif [[ "$cpu_or_gpu" == "gaudi3" ]]; then
-                gaudi_platform="gaudi3"
+            if [[ "$gaudi_platform" == "" ]]; then
+                if [[ "$cpu_or_gpu" == "gaudi2" || "$cpu_or_gpu" == "gpu" || "$cpu_or_gpu" == "g" ]]; then
+                    gaudi_platform="gaudi2"
+                elif [[ "$cpu_or_gpu" == "gaudi3" ]]; then
+                    gaudi_platform="gaudi3"
+                fi
             fi
             cpu_or_gpu="g"
             deploy_habana_ai_operator="yes"            


### PR DESCRIPTION
The input value of "gaudi3" is not preserved in the "gaudi_platform" variable because the "cpu_or_gpu" value is reset to "g" after initial processing. Subsequent calls of read_config_file() will see 'cpu_or_gpu=="g"' and reset gaudi_platform to "gaudi2".

This PR prevents that by only setting "gaudi_platform" the first time it is called.