### PR TITLE
Enable ubuntu24 on Enterprise Inference

### DIFF
--- a/core/inventory/metadata/vars/inference_common.yml
+++ b/core/inventory/metadata/vars/inference_common.yml
@@ -3,5 +3,5 @@
 helm_charts_base: "{{ lookup('env', 'PWD') }}/helm-charts"
 remote_home_dir: "{{ lookup('env', 'PWD') }}/scripts"
 remote_helm_charts_base: "/tmp/helm-charts"
-ansible_python_interpreter: /usr/bin/python3
+ansible_python_interpreter: "{{ lookup('env', 'ANSIBLE_PYTHON_INTERPRETER') or '/usr/bin/python3' }}"
 remote_home_scripts_dir: "{{ lookup('env', 'PWD') }}/scripts"

--- a/core/inventory/metadata/vars/inference_llm_models.yml
+++ b/core/inventory/metadata/vars/inference_llm_models.yml
@@ -1,6 +1,6 @@
 # Copyright (C) 2024-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-ansible_python_interpreter: /usr/bin/python3
+ansible_python_interpreter: "{{ lookup('env', 'ANSIBLE_PYTHON_INTERPRETER') or '/usr/bin/python3' }}"
 helm_charts_base: "{{ lookup('env', 'PWD') }}/helm-charts"
 remote_home_dir: "{{ lookup('env', 'PWD') }}/scripts"
 remote_helm_charts_base: "/tmp/helm-charts"

--- a/core/lib/system/setup-env.sh
+++ b/core/lib/system/setup-env.sh
@@ -70,7 +70,7 @@ setup_initial_env() {
     else
         echo "Virtual environment activated successfully. Path: $VIRTUAL_ENV"
     fi                 
-           
+    export ANSIBLE_PYTHON_INTERPRETER="$VENVDIR/bin/python"       
     export PIP_BREAK_SYSTEM_PACKAGES=1
     $VENVDIR/bin/python3 -m pip install --upgrade pip
     $VENVDIR/bin/python3 -m pip install -U -r requirements.txt    


### PR DESCRIPTION
Enabling Enterprise Inference on ubuntu 24

This pull request enables Enterprise Inference to  be deployed on ubuntu 24

Interpreter configuration improvements:

* Updated `ansible_python_interpreter` in both `inference_common.yml` and `inference_llm_models.yml` to use the `ANSIBLE_PYTHON_INTERPRETER` environment variable if set, falling back to `/usr/bin/python3` otherwise. [[1]](diffhunk://#diff-67211f95180122f04f489c12678f6554c1396ccb1194633be88fee895e87fc38L6-R6) [[2]](diffhunk://#diff-540663015ec96df5ed1e6ad124077bc6b0bc15404f9344352f28c21e38c4a7caL3-R3)

Environment setup enhancements:

* Modified `setup-env.sh` to export `ANSIBLE_PYTHON_INTERPRETER` as the virtual environment's Python binary, ensuring Ansible uses the correct interpreter.