### PR TITLE
Added llamacpp model runtime with docker based deployment

### DIFF
--- a/blueprints/llamacpp/Dockerfile-llamacpp
+++ b/blueprints/llamacpp/Dockerfile-llamacpp
@@ -1,0 +1,49 @@
+FROM intel/oneapi-basekit:latest
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LLAMA_CPP_REPO=https://github.com/ggml-org/llama.cpp.git
+ARG LLAMA_CPP_REF=master
+
+SHELL ["/bin/bash", "-lc"]
+
+# Base packages needed for building llama.cpp
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    cmake \
+    ninja-build \
+    build-essential \
+    pkg-config \
+    ca-certificates \
+    curl \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt
+
+# Clone source
+RUN git clone --depth 1 --branch "${LLAMA_CPP_REF}" "${LLAMA_CPP_REPO}" llama.cpp
+
+WORKDIR /opt/llama.cpp
+
+# Build with Intel oneAPI compilers + oneMKL BLAS
+RUN source /opt/intel/oneapi/setvars.sh --force && \
+    cmake -S . -B build -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_C_COMPILER=icx \
+      -DCMAKE_CXX_COMPILER=icpx \
+      -DGGML_BLAS=ON \
+      -DGGML_BLAS_VENDOR=Intel10_64lp \
+      -DGGML_NATIVE=ON \
+      -DLLAMA_CURL=ON \
+      -DLLAMA_OPENSSL=ON && \
+    cmake --build build -j"$(nproc)"
+
+# Write startup wrapper inline
+RUN printf '#!/usr/bin/env bash\nset -euo pipefail\nsource /opt/intel/oneapi/setvars.sh --force\nexec "$@"\n' > /usr/local/bin/llama-env && \
+    chmod +x /usr/local/bin/llama-env
+
+ENV PATH="/opt/llama.cpp/build/bin:${PATH}"
+ENV OCL_ICD_FILENAMES=""
+WORKDIR /workspace
+
+ENTRYPOINT ["/bin/bash", "-c", "set +u; source /opt/intel/oneapi/setvars.sh --force; mkdir -p /logs; /opt/llama.cpp/build/bin/llama-server --host 0.0.0.0 -c 8192 -t 6 \"$@\" 2>&1 | tee /logs/llama-server.log", "--"]

--- a/blueprints/llamacpp/Dockerfile-llamacpp
+++ b/blueprints/llamacpp/Dockerfile-llamacpp
@@ -2,7 +2,7 @@ FROM intel/oneapi-basekit:latest
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG LLAMA_CPP_REPO=https://github.com/ggml-org/llama.cpp.git
-ARG LLAMA_CPP_REF=master
+ARG LLAMA_CPP_REF=b8750
 
 SHELL ["/bin/bash", "-lc"]
 

--- a/blueprints/llamacpp/README.md
+++ b/blueprints/llamacpp/README.md
@@ -1,0 +1,50 @@
+# llama.cpp — Intel oneAPI with VMWare Foundation
+
+Runs [llama.cpp](https://github.com/ggml-org/llama.cpp) `llama-server` built with Intel oneAPI compilers and oneMKL BLAS for optimized CPU inference.
+
+## Build & Run
+
+**1. Build the image** (output logged to `$HOME/logs/docker-build.log`):
+
+```bash
+mkdir -p $HOME/logs
+sudo docker build -f Dockerfile-llamacpp -t llamacpp-intel:latest . \
+  2>&1 | tee $HOME/logs/docker-build.log
+```
+
+**2. Stop any existing container, then start a fresh one:**
+
+```bash
+sudo docker stop llamacpp 2>/dev/null || true
+
+sudo docker run --rm -d \
+  --ipc=host --net=host \
+  -v $HOME/models:/root/.cache/huggingface \
+  -v $HOME/logs:/logs \
+  --workdir /workspace \
+  --name llamacpp \
+  llamacpp-intel:latest \
+  --hf-repo win10/DeepSeek-Coder-V2-Lite-Instruct-Q8_0-GGUF \
+  --hf-file deepseek-coder-v2-lite-instruct-q8_0.gguf
+```
+
+- `--hf-repo` / `--hf-file` — HuggingFace model to serve (swap to use a different model)
+- Models are cached in `$HOME/models` — downloaded once, reused on subsequent runs
+- Build logs: `$HOME/logs/docker-build.log`
+- Server logs: `$HOME/logs/llama-server.log`
+- Server listens on `http://localhost:8080`
+
+## Test
+
+```bash
+curl http://localhost:8080/v1/completions \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"model": "win10/DeepSeek-Coder-V2-Lite-Instruct-Q8_0-GGUF", "prompt": "What is Deep Learning?", "max_tokens": 25, "temperature": 0}'
+```
+
+## Stop
+
+```bash
+sudo docker stop llamacpp
+```

--- a/blueprints/llamacpp/README.md
+++ b/blueprints/llamacpp/README.md
@@ -2,6 +2,8 @@
 
 Runs [llama.cpp](https://github.com/ggml-org/llama.cpp) `llama-server` built with Intel oneAPI compilers and oneMKL BLAS for optimized CPU inference.
 
+> **Note:** You can use any GGUF model from Hugging Face. The examples below use specific models, but you can replace them with any GGUF model by setting the appropriate environment variables.
+
 ## Build & Run
 
 **1. Build the image** (output logged to `$HOME/logs/docker-build.log`):
@@ -12,7 +14,26 @@ sudo docker build -f Dockerfile-llamacpp -t llamacpp-intel:latest . \
   2>&1 | tee $HOME/logs/docker-build.log
 ```
 
-**2. Stop any existing container, then start a fresh one:**
+**2. Set environment variables for your model:**
+
+```bash
+# Example 1: Gemma 3 1B IT (default)
+export MODEL_REPO="unsloth/gemma-3-1b-it-GGUF"
+export MODEL_FILE="gemma-3-1b-it-Q4_K_M.gguf"
+export MODEL_NAME="gemma-3-1b-it"
+
+# Example 2: Gemma 3 4B IT
+# export MODEL_REPO="google/gemma-2-2b-it-GGUF"
+# export MODEL_FILE="gemma-2-2b-it-Q8_0.gguf"
+# export MODEL_NAME="gemma-3-4b-it"
+
+# Example 3: Any other GGUF model from Hugging Face
+# export MODEL_REPO="<huggingface-username>/<repo-name>"
+# export MODEL_FILE="<model-filename>.gguf"
+# export MODEL_NAME="<model-name>"
+```
+
+**3. Stop any existing container, then start a fresh one:**
 
 ```bash
 sudo docker stop llamacpp 2>/dev/null || true
@@ -24,11 +45,13 @@ sudo docker run --rm -d \
   --workdir /workspace \
   --name llamacpp \
   llamacpp-intel:latest \
-  --hf-repo win10/DeepSeek-Coder-V2-Lite-Instruct-Q8_0-GGUF \
-  --hf-file deepseek-coder-v2-lite-instruct-q8_0.gguf
+  --hf-repo ${MODEL_REPO} \
+  --hf-file ${MODEL_FILE}
 ```
 
-- `--hf-repo` / `--hf-file` — HuggingFace model to serve (swap to use a different model)
+- `MODEL_REPO` — HuggingFace repository containing the GGUF model
+- `MODEL_FILE` — GGUF model file name
+- `MODEL_NAME` — Model name for API requests
 - Models are cached in `$HOME/models` — downloaded once, reused on subsequent runs
 - Build logs: `$HOME/logs/docker-build.log`
 - Server logs: `$HOME/logs/llama-server.log`
@@ -36,11 +59,49 @@ sudo docker run --rm -d \
 
 ## Test
 
+### Completions API
+
 ```bash
 curl http://localhost:8080/v1/completions \
   -X POST \
   -H "Content-Type: application/json" \
-  -d '{"model": "win10/DeepSeek-Coder-V2-Lite-Instruct-Q8_0-GGUF", "prompt": "What is Deep Learning?", "max_tokens": 25, "temperature": 0}'
+  -d '{"model": "'"${MODEL_NAME}"'", "prompt": "What is Deep Learning?", "max_tokens": 25, "temperature": 0}'
+```
+
+### Chat Completions API
+
+```bash
+# Set BASE_URL and TOKEN (if using with the gateway)
+export BASE_URL="http://localhost:8080"
+export TOKEN="your-token-here"  # or leave empty if no auth
+
+curl -k ${BASE_URL}/v1/chat/completions -X POST \
+  -d '{
+    "model": "'"${MODEL_NAME}"'",
+    "messages": [
+      {"role": "user", "content": "What is Deep Learning?"}
+    ],
+    "max_tokens": 25,
+    "temperature": 0
+  }' \
+  -H 'Content-Type: application/json'
+```
+
+**Example with Gemma 3 1B IT:**
+
+```bash
+export MODEL_NAME="gemma-3-1b-it"
+
+curl -k ${BASE_URL}/v1/chat/completions -X POST \
+  -d '{
+    "model": "'"${MODEL_NAME}"'",
+    "messages": [
+      {"role": "user", "content": "What is Deep Learning?"}
+    ],
+    "max_tokens": 25,
+    "temperature": 0
+  }' \
+  -H 'Content-Type: application/json'
 ```
 
 ## Stop


### PR DESCRIPTION
This pull request introduces a new Dockerfile and README for running `llama.cpp` with Intel oneAPI compilers and oneMKL BLAS, providing optimized CPU inference for the `llama-server`. The Dockerfile sets up the environment, builds `llama.cpp` from source with Intel optimizations, and configures the container for easy model serving. The README gives step-by-step instructions for building, running, and testing the container.

**Documentation and usage instructions:**

* Added `README.md` with detailed build, run, and test instructions for the new Dockerfile. The README explains how to build the image, start and stop the container, configure model caching, access logs, and test the server endpoint.